### PR TITLE
Sanitize flags.guess for AIX

### DIFF
--- a/flags.guess
+++ b/flags.guess
@@ -179,6 +179,9 @@ case $my_FC in
         # when encountering errors: ...relocation truncated to fit: R_PPC_LOCAL24PC...
         # one should also use additional flags:
         # CFLAGS = -Wl,-relax
+        # Note that the above message would only occur on a linux machine not on AIX.
+        # "relax" is not an option for the AIX linker and is interpreted in ways that will
+        # in binaries that are not executable.
         #
 # deleted -qxflag=dvz because it requires handler function __xl_dzx and thus linking will fail.
 #
@@ -186,7 +189,7 @@ case $my_FC in
 # other compilers. There is a small decrease in performance, but generally
 # it is small or negligible compared to other issues like slow I/O.
         DEF_FFLAGS="-qassert=contig -qhot -q64 -qtune=auto -qarch=auto -qcache=auto -qfree=f90 -qsuffix=f=f90 -qhalt=w -qlanglvl=2003std -g -qsuppress=1518-234 -qsuppress=1518-317 -qsuppress=1518-318 -qsuppress=1500-036"
-        OPT_FFLAGS="-O4 -qstrict -Q -Q+rank,swap_all -Wl,-relax"
+        OPT_FFLAGS="-O4 -qstrict"
         # Options -qreport -qsource -qlist create a *.lst file containing detailed information about vectorization.
         DEBUG_FFLAGS="-g -O0 -C -qddim -qfullpath -qflttrap=overflow:zerodivide:invalid:enable -qfloat=nans -qinitauto=7FBFFFFF"
         #


### PR DESCRIPTION
The current values of flags.guess for xlf:
 * contain old deprecated flags (```-Q -Q+rank,swap_all```) that are mostly ignored
 * contain linker flags that would work on linux but lead to unusable binaries on AIX

On the later ```-Wl,-relax``` on AIX will be interpreted by the linker as ```-r -e"lax"``` which will mark the binary as not executable (-r) and change the entry point for the executable to "lax" - and since there is no such entry point, nothing can be executed and you get an interesting and misleading error from AIX. See 
http://www-01.ibm.com/support/knowledgecenter/ssw_aix_61/com.ibm.aix.cmds3/ld.htm?lang=en for ld flags on AIX.

I added some notes in the file. 

To finish the notes indicate that ```-Wl,-relax``` was introduced to solve linking problem leading to a "R_PPC_LOCAL24PC" diagnostics. Those are usually meaning that you are trying to mix pic objects that have different bitness (32 vs 64). As such -relax is unlikely to solve the problem unless you see a wrong library during the linking but not during execution. A scenario that I can only imagine happening on a BlueGene machine.