### PR TITLE
Fix a fault example(TPV16) with wrong fault plane

### DIFF
--- a/EXAMPLES/fault_examples/tpv103/TPV103.py
+++ b/EXAMPLES/fault_examples/tpv103/TPV103.py
@@ -25,7 +25,7 @@ entities=['face']
 define_boundaries(entities,xmin,xmax,ymin,ymax,zmin,zmax)
 
 cubit.cmd('block 1 name "elastic 1" ')      # elastic material  
-cubit.cmd('block 1 attribute count 5')                         
+cubit.cmd('block 1 attribute count 6')                         
 cubit.cmd('block 1 attribute index 1 1')    # flag for material
 cubit.cmd('block 1 attribute index 2 6000') # vp
 cubit.cmd('block 1 attribute index 3 3464') # vs
@@ -34,12 +34,13 @@ cubit.cmd('block 1 attribute index 5 13')   # Qmu
 cubit.cmd('block 1 attribute index 6 0')     # anisotropy_flag
 
 cubit.cmd('block 2 name "elastic 2" ')    
-cubit.cmd('block 2 attribute count 5') 
+cubit.cmd('block 2 attribute count 6') 
 cubit.cmd('block 2 attribute index 1 1') 
 cubit.cmd('block 2 attribute index 2 6000')
 cubit.cmd('block 2 attribute index 3 3464')
 cubit.cmd('block 2 attribute index 4 2670')
 cubit.cmd('block 2 attribute index 5 13')  
+cubit.cmd('block 2 attribute index 6 0')  
  
 #### Export to SPECFEM3D format using cubit2specfem3d.py of GEOCUBIT 
  

--- a/EXAMPLES/fault_examples/tpv16/TPV16.py
+++ b/EXAMPLES/fault_examples/tpv16/TPV16.py
@@ -49,7 +49,7 @@ cubit2specfem3d.export2SPECFEM3D('MESH')
 
 
 Au = [8]   # A_up
-Ad = [13]  # A_down
+Ad = [3]  # A_down
 faultA = fault_input(1,Au,Ad)
 
 


### PR DESCRIPTION
All the fault examples have been tested under CUBIT13.0 with a coarser mesh size.