### PR TITLE
add one comment in get_force.f90

### DIFF
--- a/src/shared/get_force.f90
+++ b/src/shared/get_force.f90
@@ -100,6 +100,12 @@
     read(string(12:len_trim(string)),*) t_shift(isource)
 
     ! read f0 (stored in hdur() array for convenience, to use the same array as for CMTSOLUTION)
+    ! Please be careful, if you meet an error in reading the file FORCESOLUTION,
+    ! such as you still write “hdur:” instead of “f0:”
+    ! Please change your file or do following change in the code, such as changing 
+    ! read(string(4:len_trim(string)),*) hdur(isource)
+    ! to 
+    ! read(string(6:len_trim(string)),*) hdur(isource)
     read(IIN,"(a)") string
     read(string(4:len_trim(string)),*) hdur(isource)
 


### PR DESCRIPTION
add one comment in get_force.f90 in order to facilitate the older user who still use the old FORCESOLUTION file to find out why the code stop with error
forrtl: severe (59): list-directed I/O syntax error, unit -5, file Internal List-Directed Read