### PR TITLE
committed changes by Florian Schumacher to fix the following small bug:

### DIFF
--- a/src/specfem3D/compute_add_sources_viscoelastic.f90
+++ b/src/specfem3D/compute_add_sources_viscoelastic.f90
@@ -140,8 +140,8 @@
               if (USE_RICKER_TIME_FUNCTION) then
                 stf = comp_source_time_function_rickr(time_source_dble,hdur(isource))
               else
-                ! use a very small duration of 5*DT to mimic a Dirac in time
-                stf = comp_source_time_function_gauss(time_source_dble,5.d0*DT)
+                !stf = comp_source_time_function_gauss(time_source_dble,5.d0*DT) ! COMMENTED BY FS FS -> do no longer use hard-coded hdur_gaussian = 5*DT, but actual value of hdur_gaussian
+                stf = comp_source_time_function_gauss(time_source_dble,hdur_gaussian(isource)) !! ADDED BY FS FS -> use actual value of hdur_gaussian as half duration
               endif
 
               ! add the tilted force source array
@@ -504,7 +504,7 @@
                 stf = comp_source_time_function_rickr(dble(NSTEP-it)*DT-t0-tshift_src(isource),hdur(isource))
               else
                 ! use a very small duration of 5*DT to mimic a Dirac in time
-                stf = comp_source_time_function_gauss(dble(NSTEP-it)*DT-t0-tshift_src(isource),5.d0*DT)
+                stf = comp_source_time_function_gauss(dble(NSTEP-it)*DT-t0-tshift_src(isource),5.d0*DT) ! FS FS  does it also here make sense to replace 5.d0*DT by hdur_gaussian(isource) ? looks like it
               endif
 
               ! add the tilted force source array
@@ -684,7 +684,7 @@
             stf_pre_compute(isource) = comp_source_time_function_rickr(dble(it-1)*DT-t0-tshift_src(isource),hdur(isource))
           else
             ! use a very small duration of 5*DT to mimic a Dirac in time
-            stf_pre_compute(isource) = comp_source_time_function_gauss(dble(it-1)*DT-t0-tshift_src(isource),5.d0*DT)
+            stf_pre_compute(isource) = comp_source_time_function_gauss(dble(it-1)*DT-t0-tshift_src(isource),5.d0*DT)  ! FS FS  does it also here make sense to replace 5.d0*DT by hdur_gaussian(isource) ? looks like it
           endif
         else
           if (USE_RICKER_TIME_FUNCTION) then
@@ -850,7 +850,7 @@
             stf_pre_compute(isource) = comp_source_time_function_rickr(dble(NSTEP-it)*DT-t0-tshift_src(isource),hdur(isource))
           else
             ! use a very small duration of 5*DT to mimic a Dirac in time
-            stf_pre_compute(isource) = comp_source_time_function_gauss(dble(NSTEP-it)*DT-t0-tshift_src(isource),5.d0*DT)
+            stf_pre_compute(isource) = comp_source_time_function_gauss(dble(NSTEP-it)*DT-t0-tshift_src(isource),5.d0*DT) ! FS FS  does it also here make sense to replace 5.d0*DT by hdur_gaussian(isource) ? looks like it
           endif
         else
           if (USE_RICKER_TIME_FUNCTION) then

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -177,7 +177,12 @@
   call max_all_all_dp(t0_acoustic,t0)
 
   ! point force sources will start depending on the frequency given by hdur
-  !if (USE_FORCE_POINT_SOURCE .or. USE_RICKER_TIME_FUNCTION) then !! COMMENTED BY FS FS -> account for the case USE_FORCE_POINT_SOURCE but NOT using a ricker (i.e. using a gaussian), in this case the above defined t0 = - 2.0d0 * minval(tshift_src(:) - hdur(:)) is correct (analogous to using error function in case of moment tensor sources). You only need to be aware that hdur=0 then has a different behaviour for point forces (compared with moment tensor sources): then hdur is set to TINYVAL and NOT to 5*DT as in case of moment tensor source (Heaviside)
+  !if (USE_FORCE_POINT_SOURCE .or. USE_RICKER_TIME_FUNCTION) then
+!! COMMENTED BY FS FS -> account for the case USE_FORCE_POINT_SOURCE but NOT using a ricker (i.e. using a gaussian),
+! in this case the above defined t0 = - 2.0d0 * minval(tshift_src(:) - hdur(:)) is correct
+! (analogous to using error function in case of moment tensor sources). You only need to be aware that hdur=0
+! then has a different behaviour for point forces (compared with moment tensor sources):
+! then hdur is set to TINYVAL and NOT to 5*DT as in case of moment tensor source (Heaviside)
   if (USE_RICKER_TIME_FUNCTION) then !! ADDED BY FS FS
     ! note: point force sources will give the dominant frequency in hdur,
     !       thus the main period is 1/hdur.

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -177,7 +177,8 @@
   call max_all_all_dp(t0_acoustic,t0)
 
   ! point force sources will start depending on the frequency given by hdur
-  if (USE_FORCE_POINT_SOURCE .or. USE_RICKER_TIME_FUNCTION) then
+  !if (USE_FORCE_POINT_SOURCE .or. USE_RICKER_TIME_FUNCTION) then !! COMMENTED BY FS FS -> account for the case USE_FORCE_POINT_SOURCE but NOT using a ricker (i.e. using a gaussian), in this case the above defined t0 = - 2.0d0 * minval(tshift_src(:) - hdur(:)) is correct (analogous to using error function in case of moment tensor sources). You only need to be aware that hdur=0 then has a different behaviour for point forces (compared with moment tensor sources): then hdur is set to TINYVAL and NOT to 5*DT as in case of moment tensor source (Heaviside)
+  if (USE_RICKER_TIME_FUNCTION) then !! ADDED BY FS FS
     ! note: point force sources will give the dominant frequency in hdur,
     !       thus the main period is 1/hdur.
     !       also, these sources use a Ricker source time function instead of a gaussian.


### PR DESCRIPTION
I came accross the following problem with SPECFEM3d_Cartesian:

Looking at the latest code on GitHub, I noticed that the flags 
USE_RICKER_TIME_FUNCTION and USE_FORCE_POINT_SOURCE can now be used 
independently of each other in any combination, which allows for point force
and moment tensor sources using either, ricker or gaussian source time
functions (or error function, in case of moment tensor) . This is great! (was
strongly restricted before).

However, there seem to be some remaining old code (in devel branch) which
prevents this from working properly:

1) src/specfem3D/setup_sources_receivers.f90 , subroutine setup_sources() : t0
is (re)defined as
 t0 = - 1.2d0 * minval(tshift_src(:) - 1.0d0/hdur(:)) in case of
(USE_FORCE_POINT_SOURCE .or. USE_RICKER_TIME_FUNCTION). This (re)definition
makes sense if hdur contains dominant frequency, but should not happen if you
want to use a gaussian for a point source
(since then the array hdur should actually contain half durations). From what
I can conclude at this point, you can fix this simply by removing
"USE_FORCE_POINT_SOURCE .or." from the if-clause, i.e. execute this
(re)definition only in case of USE_RICKER_TIME_FUNCTION == .true.

2) src/specfem3D/compute_add_sources_viscoelastic.f90: the function
comp_source_time_function_gauss() is always called with a fixed half duration
value of 5.d0*DT instead of hdur_gaussian(isource). Changing this to
hdur_gaussian(isource) would give the full functionality that I guess is
intended here (please do correct me, if necessary).

Making these two small corrections, the correct source time functions are
created for all types of sources, having a correct time shift t0. I have
attached the two relevant files to this email, correcting the code (see
comments containing "FS FS"). However, in compute_add_sources_viscoelastic.f90
I am not entirely sure whether all calls to comp_source_time_function_gauss()
should be modified as described above (though it looks like that to me),
because I am not much familiar with adjoint or GPU simulations. So please look
for all comments containing "FS FS". Thanks.

There is one little thing though when using a point source and not a Ricker
wavelet: The value of half duration is read from the f0 value in
FORCESOLUTION, actually meaning a value of half duration and not frequency. In
my opinion this should not be a problem, since in old SPECFEM3d versions this
confusion was similar when reading the value of center frequency from the hdur
line in file CMTSOLUTION. Also, when setting f0 = 0.0 in FORCESOLUTION, the
variable hdur is set to TINYVAL and not to 5*DT which is done in the analogous
case of using a Moment tensor source with a Heaviside. But the user could
simply write f0=5*DT to FORCESOLUTION when he needs a steep gaussian.

I hope this could help. I am happy about any feedback in case there is a 
better (more suited) solution to this.