### PR TITLE
 Fix issue Fails compile with xlf #818

### DIFF
--- a/config.guess
+++ b/config.guess
@@ -972,6 +972,9 @@ EOF
     ppc64:Linux:*:*)
 	echo powerpc64-unknown-linux-gnu
 	exit ;;
+    ppc64le:Linux:*:*)
+        echo powerpc64le-unknown-linux-gnu
+        exit ;;
     ppc:Linux:*:*)
 	echo powerpc-unknown-linux-gnu
 	exit ;;

--- a/src/decompose_mesh/program_decompose_mesh.f90
+++ b/src/decompose_mesh/program_decompose_mesh.f90
@@ -41,7 +41,7 @@ program xdecompose_mesh
 ! check usage
   do i=1,3
     call get_command_argument(i,arg(i))
-    if (i <= 3 .and. trim(arg(i)) == "") then
+    if (i <= 3 .and. trim(arg(i)) == "\0") then
       print *, 'Usage: ./xdecompose_mesh  nparts  input_directory output_directory'
       print *
       print *, '  where'

--- a/src/meshfem3D/check_mesh_quality.f90
+++ b/src/meshfem3D/check_mesh_quality.f90
@@ -361,7 +361,7 @@
     do ipoin = 1,nglob
       write(IOVTK,*) sngl(x(ipoin)),sngl(y(ipoin)),sngl(z(ipoin))
     enddo
-    write(IOVTK,*) ""
+    write(IOVTK,*) "\0"
 
     ! note: indices for vtk start at 0
     write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -370,12 +370,12 @@
             ibool(1,ispec)-1,ibool(2,ispec)-1,ibool(4,ispec)-1,ibool(3,ispec)-1, &
             ibool(5,ispec)-1,ibool(6,ispec)-1,ibool(8,ispec)-1,ibool(7,ispec)-1
     enddo
-    write(IOVTK,*) ""
+    write(IOVTK,*) "\0"
 
     ! type: hexahedra
     write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
     write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-    write(IOVTK,*) ""
+    write(IOVTK,*) "\0"
 
     write(IOVTK,'(a,i12)') "CELL_DATA ",nspec
     write(IOVTK,'(a)') "SCALARS skewness float"
@@ -383,7 +383,7 @@
     do ispec = 1,nspec
       write(IOVTK,*) tmp1(ispec)
     enddo
-    write(IOVTK,*) ""
+    write(IOVTK,*) "\0"
     close(IOVTK)
 
     deallocate(tmp1)

--- a/src/meshfem3D/create_meshfem_mesh.f90
+++ b/src/meshfem3D/create_meshfem_mesh.f90
@@ -504,7 +504,7 @@
     do ispec = 1,nspec
       write(IOVTK,*) ispec_material_id(ispec)
     enddo
-    write(IOVTK,*) ""
+    write(IOVTK,*) "\0"
     close(IOVTK)
 
     ! stop mesher

--- a/src/meshfem3D/create_visual_files.f90
+++ b/src/meshfem3D/create_visual_files.f90
@@ -137,7 +137,7 @@
     do ipoin = 1,nglob
       write(66,*) sngl(nodes_coords(ipoin,1)),sngl(nodes_coords(ipoin,2)),sngl(nodes_coords(ipoin,3))
     enddo
-    write(66,*) ""
+    write(66,*) "\0"
 
     ! note: indices for vtk start at 0
     write(66,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -146,12 +146,12 @@
             ibool(1,1,1,ispec)-1,ibool(2,1,1,ispec)-1,ibool(2,2,1,ispec)-1,ibool(1,2,1,ispec)-1, &
             ibool(1,1,2,ispec)-1,ibool(2,1,2,ispec)-1,ibool(2,2,2,ispec)-1,ibool(1,2,2,ispec)-1
     enddo
-    write(66,*) ""
+    write(66,*) "\0"
 
     ! type: hexahedrons
     write(66,'(a,i12)') "CELL_TYPES ",nspec
     write(66,'(6i12)') (12,ispec=1,nspec)
-    write(66,*) ""
+    write(66,*) "\0"
 
     write(66,'(a,i12)') "CELL_DATA ",nspec
     write(66,'(a)') "SCALARS elem_val float"
@@ -159,7 +159,7 @@
     do ispec = 1,nspec
       write(66,*) ispec_material_id(ispec)
     enddo
-    write(66,*) ""
+    write(66,*) "\0"
     close(66)
 
   endif

--- a/src/meshfem3D/save_databases.F90
+++ b/src/meshfem3D/save_databases.F90
@@ -187,7 +187,7 @@
       ! format:
       ! #material_id #type-keyword #domain-name #tomo-filename #tomo_id #domain_id
       ! format example tomography: -1 tomography elastic tomography_model.xyz 0 2
-      undef_mat_prop(:,:) = ''
+      undef_mat_prop(:,:) = '\0'
       ! material id
       write(undef_mat_prop(1,1),*) mat_id
       ! name

--- a/src/shared/read_parameter_file.F90
+++ b/src/shared/read_parameter_file.F90
@@ -405,7 +405,7 @@
       IMODEL = IMODEL_TOMO
     case ('sep')
       IMODEL = IMODEL_SEP
-      if (trim(SEP_MODEL_DIRECTORY) == '') then
+      if (trim(SEP_MODEL_DIRECTORY) == '\0') then
         stop 'Error using sep model requires defining a SEP_MODEL_DIRECTORY.'
       endif
       !inquire(directory=trim(SEP_MODEL_DIRECTORY), exists=sep_dir_exists)

--- a/src/shared/write_VTK_data.f90
+++ b/src/shared/write_VTK_data.f90
@@ -64,7 +64,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -72,12 +72,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   write(IOVTK,'(a,i12)') "CELL_DATA ",nspec
   write(IOVTK,'(a)') "SCALARS elem_flag integer"
@@ -85,7 +85,7 @@
   do ispec = 1,nspec
     write(IOVTK,*) elem_flag(ispec)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
   close(IOVTK)
 
 
@@ -131,7 +131,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -139,12 +139,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   write(IOVTK,'(a,i12)') "CELL_DATA ",nspec
   write(IOVTK,'(a)') "SCALARS elem_flag integer"
@@ -156,7 +156,7 @@
       write(IOVTK,*) 0
     endif
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
   close(IOVTK)
 
 
@@ -207,7 +207,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -215,12 +215,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! iflag field on global nodeset
   !allocate(mask_ibool(nglob),flag_val(nglob),stat=ier)
@@ -248,7 +248,7 @@
   do i = 1,nglob
       write(IOVTK,*) flag_val(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   close(IOVTK)
 
@@ -299,7 +299,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -307,12 +307,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! iflag field on global nodeset
   allocate(mask_ibool(nglob),flag_val(nglob),stat=ier)
@@ -339,7 +339,7 @@
   do i = 1,nglob
       write(IOVTK,*) flag_val(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   close(IOVTK)
 
@@ -395,7 +395,7 @@
 
     write(IOVTK,'(3e18.6)') xstore_dummy(iglob),ystore_dummy(iglob),zstore_dummy(iglob)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   close(IOVTK)
 
@@ -442,7 +442,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -450,12 +450,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! vector data for each cell
   write(IOVTK,'(a,i12)') "CELL_DATA ",nspec
@@ -464,7 +464,7 @@
     write(IOVTK,*) elem_vector(1,i),elem_vector(2,i),elem_vector(3,i)
   enddo
 
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
   close(IOVTK)
 
 
@@ -510,7 +510,7 @@
   do i=1,nglob
     write(IOVTK,'(3e18.6)') xstore_dummy(i),ystore_dummy(i),zstore_dummy(i)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! note: indices for vtk start at 0
   write(IOVTK,'(a,i12,i12)') "CELLS ",nspec,nspec*9
@@ -518,12 +518,12 @@
     write(IOVTK,'(9i12)') 8,ibool(1,1,1,ispec)-1,ibool(NGLLX,1,1,ispec)-1,ibool(NGLLX,NGLLY,1,ispec)-1,ibool(1,NGLLY,1,ispec)-1, &
           ibool(1,1,NGLLZ,ispec)-1,ibool(NGLLX,1,NGLLZ,ispec)-1,ibool(NGLLX,NGLLY,NGLLZ,ispec)-1,ibool(1,NGLLY,NGLLZ,ispec)-1
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   ! type: hexahedrons
   write(IOVTK,'(a,i12)') "CELL_TYPES ",nspec
   write(IOVTK,'(6i12)') (12,ispec=1,nspec)
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
 
   write(IOVTK,'(a,i12)') "CELL_DATA ",nspec
   write(IOVTK,'(a)') "SCALARS elem_val float"
@@ -531,7 +531,7 @@
   do ispec = 1,nspec
     write(IOVTK,*) elem_flag(ispec)
   enddo
-  write(IOVTK,*) ""
+  write(IOVTK,*) "\0"
   close(IOVTK)
 
 

--- a/src/specfem3D/fault_solver_dynamic.f90
+++ b/src/specfem3D/fault_solver_dynamic.f90
@@ -430,7 +430,7 @@ contains
   if (n == 0) return
 
   do i=1,n
-    shapeval = ''
+    shapeval = '\0'
     val  = 0e0_CUSTOM_REAL
     valh = 0e0_CUSTOM_REAL
     xc = 0e0_CUSTOM_REAL


### PR DESCRIPTION
I've modified the null char/string literals to use a null escape sequence,  this allows it to build using xlf.
Built on a power8/le linux machine,  and tested with current gcc as well.


