### PR TITLE
Split adjoint sources array

### DIFF
--- a/src/cuda/mesh_constants_cuda.h
+++ b/src/cuda/mesh_constants_cuda.h
@@ -234,14 +234,14 @@ typedef texture<float, cudaTextureType1D, cudaReadModeElementType> realw_texture
 //   however, compiler tends to use texture loads for restricted memory arrays, which might slow down performance
 //
 // non-restricted (default)
-typedef const realw* realw_const_p;
+//typedef const realw* realw_const_p;
 // restricted
-//typedef const realw* __restrict__ realw_const_p;
+typedef const realw* __restrict__ realw_const_p;
 //
 // non-restricted (default)
-typedef realw* realw_p;
+//typedef realw* realw_p;
 // restricted
-//typedef realw* __restrict__ realw_p;
+typedef realw* __restrict__ realw_p;
 
 // wrapper for global memory load function
 // usage:  val = get_global_cr( &A[index] );
@@ -408,11 +408,11 @@ typedef struct mesh_ {
   realw* d_station_seismo_field;
   realw* h_station_seismo_field;
 
-  double* d_hxir, *d_hetar, *d_hgammar;
+  realw* d_hxir, *d_hetar, *d_hgammar;
   double* d_dxd, *d_dyd, *d_dzd;
   double* d_vxd, *d_vyd, *d_vzd;
   double* d_axd, *d_ayd, *d_azd;
-  realw* d_seismograms_d, *d_seismograms_v, *d_seismograms_a;
+  realw* d_seismograms_d, *d_seismograms_v, *d_seismograms_a, *d_seismograms_p;
   double* d_nu;
 
   realw* h_seismograms_d_it;
@@ -421,6 +421,7 @@ typedef struct mesh_ {
 
   // adjoint receivers/sources
   int nadj_rec_local;
+  realw* d_source_adjoint;
   realw* d_adj_sourcearrays;
   realw* h_adj_sourcearrays_slice;
   int* d_pre_computed_irec;

--- a/src/cuda/write_seismograms_cuda.cu
+++ b/src/cuda/write_seismograms_cuda.cu
@@ -68,7 +68,7 @@ __device__ double my_atomicAdd(double* address, double val) {
 __global__ void compute_interpolated_dva_plus_seismogram(int nrec_local,
                                                          realw* displ, realw* veloc, realw* accel,
                                                          int* d_ibool,
-                                                         double* hxir, double* hetar, double* hgammar,
+                                                         realw* hxir, realw* hetar, realw* hgammar,
                                                          realw* seismograms_d, realw* seismograms_v, realw* seismograms_a,
                                                          double* nu,
                                                          int* number_receiver_global,

--- a/src/specfem3D/compute_forces_acoustic_calling_routine.f90
+++ b/src/specfem3D/compute_forces_acoustic_calling_routine.f90
@@ -172,13 +172,7 @@ subroutine compute_forces_acoustic_calling()
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
       !
-      call compute_add_sources_acoustic(NSPEC_AB,NGLOB_AB,potential_dot_dot_acoustic, &
-                          ibool, &
-                          NSOURCES,myrank,it,islice_selected_source,ispec_selected_source, &
-                          sourcearrays,kappastore,ispec_is_acoustic, &
-                          SIMULATION_TYPE,NSTEP, &
-                          nrec,islice_selected_rec,ispec_selected_rec, &
-                          nadj_rec_local,adj_sourcearrays,NTSTEP_BETWEEN_READ_ADJSRC)
+      call compute_add_sources_acoustic()
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI
@@ -414,12 +408,8 @@ subroutine compute_forces_acoustic_backward_calling()
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
       !
-      call compute_add_sources_acoustic_backward(NSPEC_AB, &
-                                    ibool, &
-                                    NSOURCES,myrank,it,islice_selected_source,ispec_selected_source, &
-                                    sourcearrays,kappastore,ispec_is_acoustic, &
-                                    SIMULATION_TYPE,NSTEP,NGLOB_ADJOINT, &
-                                    b_potential_dot_dot_acoustic)
+      call compute_add_sources_acoustic_backward()
+
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI
@@ -549,12 +539,7 @@ subroutine compute_forces_acoustic_GPU_calling()
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
       !
-      call compute_add_sources_acoustic_GPU(NSPEC_AB, &
-                                    NSOURCES,it, &
-                                    ispec_is_acoustic,SIMULATION_TYPE,NSTEP, &
-                                    nrec,islice_selected_rec,ispec_selected_rec, &
-                                    nadj_rec_local,adj_sourcearrays, &
-                                    NTSTEP_BETWEEN_READ_ADJSRC,Mesh_pointer)
+      call compute_add_sources_acoustic_GPU()
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI

--- a/src/specfem3D/compute_forces_poroelastic_calling_routine.f90
+++ b/src/specfem3D/compute_forces_poroelastic_calling_routine.f90
@@ -197,16 +197,8 @@ subroutine compute_forces_poroelastic_calling()
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
       !
-      call compute_add_sources_poroelastic( NSPEC_AB,NGLOB_AB, &
-                          accels_poroelastic,accelw_poroelastic, &
-                          rhoarraystore,phistore,tortstore, &
-                          ibool, &
-                          NSOURCES,myrank,it,islice_selected_source,ispec_selected_source, &
-                          sourcearrays, &
-                          ispec_is_poroelastic,SIMULATION_TYPE,NSTEP,NGLOB_ADJOINT, &
-                          nrec,islice_selected_rec,ispec_selected_rec, &
-                          nadj_rec_local,adj_sourcearrays,b_accels_poroelastic,b_accelw_poroelastic, &
-                          NTSTEP_BETWEEN_READ_ADJSRC)
+      call compute_add_sources_poroelastic()
+
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI

--- a/src/specfem3D/compute_forces_viscoelastic_calling_routine.F90
+++ b/src/specfem3D/compute_forces_viscoelastic_calling_routine.F90
@@ -168,14 +168,7 @@ subroutine compute_forces_viscoelastic_calling()
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
       !
       ! adds source term (single-force/moment-tensor solution)
-      call compute_add_sources_viscoelastic(NSPEC_AB,NGLOB_AB,accel, &
-                                            ibool, &
-                                            NSOURCES,myrank,it,islice_selected_source,ispec_selected_source, &
-                                            sourcearrays, &
-                                            ispec_is_elastic,SIMULATION_TYPE,NSTEP, &
-                                            nrec,islice_selected_rec,ispec_selected_rec, &
-                                            nadj_rec_local,adj_sourcearrays, &
-                                            NTSTEP_BETWEEN_READ_ADJSRC,NOISE_TOMOGRAPHY)
+      call compute_add_sources_viscoelastic()
 
     endif ! iphase
 
@@ -378,12 +371,8 @@ subroutine compute_forces_viscoelastic_backward_calling()
       ! adds source term (single-force/moment-tensor solution)
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
-      call compute_add_sources_viscoelastic_backward( NSPEC_AB,NGLOB_AB, &
-                          ibool, &
-                          NSOURCES,myrank,it,islice_selected_source,ispec_selected_source, &
-                          sourcearrays, &
-                          ispec_is_elastic,SIMULATION_TYPE,NSTEP,NGLOB_ADJOINT, &
-                          b_accel,NOISE_TOMOGRAPHY)
+      call compute_add_sources_viscoelastic_backward()
+ 
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI
@@ -556,13 +545,8 @@ subroutine compute_forces_viscoelastic_GPU_calling()
       ! adds source term (single-force/moment-tensor solution)
       ! note: we will add all source contributions in the first pass, when iphase == 1
       !       to avoid calling the same routine twice and to check if the source element is an inner/outer element
-      call compute_add_sources_viscoelastic_GPU(NSPEC_AB, &
-                          NSOURCES,it, &
-                          ispec_is_elastic,SIMULATION_TYPE,NSTEP, &
-                          nrec,islice_selected_rec,ispec_selected_rec, &
-                          nadj_rec_local,adj_sourcearrays, &
-                          NTSTEP_BETWEEN_READ_ADJSRC,NOISE_TOMOGRAPHY, &
-                          Mesh_pointer)
+      call compute_add_sources_viscoelastic_GPU()
+ 
     endif ! iphase
 
     ! assemble all the contributions between slices using MPI

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -850,22 +850,15 @@
     endif
 
     ! initializes adjoint sources
-    allocate(adj_sourcearrays(nadj_rec_local,NTSTEP_BETWEEN_READ_ADJSRC,NDIM,NGLLX,NGLLY,NGLLZ),stat=ier)
-    if (ier /= 0) stop 'error allocating array adj_sourcearrays'
-    adj_sourcearrays(:,:,:,:,:,:) = 0._CUSTOM_REAL
+
+    allocate(source_adjoint(nadj_rec_local,NTSTEP_BETWEEN_READ_ADJSRC,NDIM),stat=ier)
+    if (ier /= 0) stop 'error allocating array source_adjoint'
 
     ! note:
     ! computes adjoint sources in chunks/blocks during time iterations.
     ! we moved it to compute_add_sources_viscoelastic.f90 & compute_add_sources_acoustic.f90,
     ! because we may need to read in adjoint sources block by block
 
-  else
-    ! (SIMULATION_TYPE == 1)
-    ! allocate dummy array in order to be able to use it as a subroutine argument, even if unused
-    nadj_rec_local = 0
-    NTSTEP_BETWEEN_READ_ADJSRC = 0
-    allocate(adj_sourcearrays(nadj_rec_local,NTSTEP_BETWEEN_READ_ADJSRC,NDIM,NGLLX,NGLLY,NGLLZ),stat=ier)
-    if (ier /= 0) stop 'error allocating dummy array adj_sourcearrays'
   endif
 
   ! user info

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -153,7 +153,7 @@ module specfem_par
 
 ! Lagrange interpolators at receivers
   double precision, dimension(:), allocatable :: hxir,hetar,hpxir,hpetar,hgammar,hpgammar
-  double precision, dimension(:,:), allocatable :: hxir_store,hetar_store,hgammar_store
+  real(kind=CUSTOM_REAL), dimension(:,:), allocatable :: hxir_store,hetar_store,hgammar_store
 
 ! proc numbers for MPI
   integer :: myrank, sizeprocs
@@ -243,8 +243,7 @@ module specfem_par
 
   ! adjoint sources
   character(len=MAX_STRING_LEN) :: adj_source_file
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:,:), allocatable :: adj_sourcearray
-  real(kind=CUSTOM_REAL), dimension(:,:,:,:,:,:), allocatable :: adj_sourcearrays
+  real(kind=CUSTOM_REAL), dimension(:,:,:), allocatable :: source_adjoint
   integer :: nadj_rec_local
   ! adjoint source frechet derivatives
   real(kind=CUSTOM_REAL), dimension(:), allocatable :: Mxx_der,Myy_der, &

--- a/src/specfem3D/write_output_SU.f90
+++ b/src/specfem3D/write_output_SU.f90
@@ -72,7 +72,7 @@
 
   allocate(rtmpseis(NSTEP),stat=ier)
   if (ier /= 0) stop 'error allocating rtmpseis array'
-
+if (SAVE_SEISMOGRAMS_DISPLACEMENT) then
   ! write seismograms (dx)
   open(unit=IOUT_SU, file=trim(final_LOCAL_PATH)//trim(procname)//'_dx_SU', &
        status='unknown', access='direct', recl=4, iostat=ier)
@@ -144,6 +144,34 @@
 
   enddo
   close(IOUT_SU)
+
+endif
+
+if (SAVE_SEISMOGRAMS_PRESSURE) then 
+ ! write seismograms (dz)
+  open(unit=IOUT_SU, file=trim(final_LOCAL_PATH)//trim(procname)//'_dp_SU', &
+       status='unknown', access='direct', recl=4, iostat=ier)
+
+  if (ier /= 0) stop 'error opening ***_dp_SU file'
+
+  do irec_local = 1,nrec_local
+    irec = number_receiver_global(irec_local)
+
+    ! write section header
+    call write_SU_header(irec_local,irec,nrec,NSTEP,DT,dx, &
+                         x_found(irec),y_found(irec),z_found(irec),x_found_source,y_found_source,z_found_source)
+
+    ! convert trace to real 4-byte
+    rtmpseis(1:NSTEP) = seismograms_p(1,irec_local,1:NSTEP)
+    do i=1,NSTEP
+      write(IOUT_SU,rec=irec_local*60+(irec_local-1)*NSTEP+i) rtmpseis(i)
+    enddo
+
+  enddo
+  close(IOUT_SU)
+
+endif
+
 
   end subroutine write_output_SU
 


### PR DESCRIPTION
- Adjoint sources array is split in smaller arrays, to save RAM memory and expensive transfers between CPU and GPU.
- Acousticadjoint sources are divided by the kappa of the fluid.
- SU format now supports pressure output.