### PR TITLE
Simplifying locate source and receiver routines

### DIFF
--- a/setup/constants.h.in
+++ b/setup/constants.h.in
@@ -185,9 +185,6 @@
 ! flag to exclude elements that are too far from target in receiver detection
   logical, parameter :: USE_DISTANCE_CRITERION_RECEIVERS = .true.
 
-! no Lagrange interpolation for seismograms (we then take the value at the closest NGLL point, which is less accurate but faster)
-  logical, parameter :: FASTER_RECEIVERS_POINTS_ONLY = .false.
-
 ! use this t0 as earliest starting time rather than the automatically calculated one
 ! (must be positive and bigger than the automatically one to be effective;
 !  simulation will start at t = - t0)

--- a/src/cuda/mesh_constants_cuda.h
+++ b/src/cuda/mesh_constants_cuda.h
@@ -411,7 +411,6 @@ typedef struct mesh_ {
 
   realw* d_hxir, *d_hetar, *d_hgammar;
   realw* d_seismograms_d, *d_seismograms_v, *d_seismograms_a, *d_seismograms_p;
-  realw* d_nu;
 
   // adjoint receivers/sources
   int nadj_rec_local;

--- a/src/cuda/prepare_mesh_constants_cuda.cu
+++ b/src/cuda/prepare_mesh_constants_cuda.cu
@@ -133,7 +133,7 @@ void FC_FUNC_(prepare_constants_device,
                                         int* nspec_acoustic,int* nspec_elastic,
                                         int* h_myrank,
                                         int* SAVE_FORWARD,
-                                        realw* h_xir,realw* h_etar, realw* h_gammar,double * nu,
+                                        realw* h_xir,realw* h_etar, realw* h_gammar,
                                         int* islice_selected_rec,int* NSTEP) {
 
   TRACE("prepare_constants_device");
@@ -335,27 +335,13 @@ void FC_FUNC_(prepare_constants_device,
     copy_todevice_realw((void**)&mp->d_hetar,h_etar,5*mp->nrec_local);
     copy_todevice_realw((void**)&mp->d_hgammar,h_gammar,5*mp->nrec_local);
 
-    float* h_nu;
-    h_nu=(float*)malloc(9 * sizeof(float) * mp->nrec_local);
-    int irec_loc=0;
-    for (int i=0;i < (*nrec);i++)
-      {
-      if ( mp->myrank == islice_selected_rec[i])
-        {
-         for (int j=0;j < 9;j++) h_nu[j + 9*irec_loc] = (float)nu[j + 9*i];
-         irec_loc = irec_loc + 1;
-        }
-      }
-    copy_todevice_realw((void**)&mp->d_nu,h_nu,3*3*(*nrec_local));
-    free(h_nu);
-
     print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms_d,3*(*NSTEP)*(*nrec_local)*sizeof(realw)),8101);
     print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms_v,3*(*NSTEP)*(*nrec_local)*sizeof(realw)),8101);
     print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms_a,3*(*NSTEP)*(*nrec_local)*sizeof(realw)),8101);
     print_CUDA_error_if_any(cudaMalloc((void**)&mp->d_seismograms_p,3*(*NSTEP)*(*nrec_local)*sizeof(realw)),8101);
     int * ispec_selected_rec_loc;
     ispec_selected_rec_loc = (int*)malloc(sizeof(int)*mp->nrec_local);
-    irec_loc=0;
+    int irec_loc=0;
     for(int i=0;i<*nrec;i++) { if ( mp->myrank == islice_selected_rec[i]){ ispec_selected_rec_loc[irec_loc] = h_ispec_selected_rec[i];irec_loc = irec_loc+1;}}
     copy_todevice_int((void**)&mp->d_ispec_selected_rec_loc,ispec_selected_rec_loc,mp->nrec_local);
     free(ispec_selected_rec_loc);
@@ -1466,7 +1452,6 @@ TRACE("prepare_cleanup_device");
     cudaFree(mp->d_hxir);
     cudaFree(mp->d_hetar);
     cudaFree(mp->d_hgammar);
-    cudaFree(mp->d_nu);
     cudaFree(mp->d_seismograms_d);
     cudaFree(mp->d_seismograms_v);
     cudaFree(mp->d_seismograms_a);

--- a/src/cuda/write_seismograms_cuda.cu
+++ b/src/cuda/write_seismograms_cuda.cu
@@ -36,7 +36,6 @@ __global__ void compute_elastic_seismogram_kernel(int nrec_local,
                                                   int* d_ibool,
                                                   realw* hxir, realw* hetar, realw* hgammar,
                                                   realw* seismograms,
-                                                  realw* nu,
                                                   int* ispec_selected_rec_loc,
                                                   int it)
 {
@@ -83,9 +82,9 @@ __global__ void compute_elastic_seismogram_kernel(int nrec_local,
       __syncthreads();
     }
 
-    if (tx == 0) {seismograms[0+3*irec_local+3*nrec_local*it] = nu[0+3*(0+3*irec_local)]*sh_dxd[0] + nu[0+3*(1+3*irec_local)]*sh_dyd[0] + nu[0+3*(2+3*irec_local)]*sh_dzd[0];}
-    if (tx == 1) {seismograms[1+3*irec_local+3*nrec_local*it] = nu[1+3*(0+3*irec_local)]*sh_dxd[0] + nu[1+3*(1+3*irec_local)]*sh_dyd[0] + nu[1+3*(2+3*irec_local)]*sh_dzd[0];}
-    if (tx == 2) {seismograms[2+3*irec_local+3*nrec_local*it] = nu[2+3*(0+3*irec_local)]*sh_dxd[0] + nu[2+3*(1+3*irec_local)]*sh_dyd[0] + nu[2+3*(2+3*irec_local)]*sh_dzd[0];}
+    if (tx == 0) {seismograms[0+3*irec_local+3*nrec_local*it] = sh_dxd[0];}
+    if (tx == 1) {seismograms[1+3*irec_local+3*nrec_local*it] = sh_dyd[0];}
+    if (tx == 2) {seismograms[2+3*irec_local+3*nrec_local*it] = sh_dzd[0];}
   }
 }
 
@@ -203,7 +202,6 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                mp->d_ibool,
                                                                                mp->d_hxir,mp->d_hetar,mp->d_hgammar,
                                                                                mp->d_seismograms_d,
-                                                                               mp->d_nu,
                                                                                mp->d_ispec_selected_rec_loc,
                                                                                it);
 
@@ -213,7 +211,6 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                mp->d_ibool,
                                                                                mp->d_hxir,mp->d_hetar,mp->d_hgammar,
                                                                                mp->d_seismograms_v,
-                                                                               mp->d_nu,
                                                                                mp->d_ispec_selected_rec_loc,
                                                                                it);
 
@@ -223,7 +220,6 @@ void FC_FUNC_(compute_seismograms_cuda,
                                                                                mp->d_ibool,
                                                                                mp->d_hxir,mp->d_hetar,mp->d_hgammar,
                                                                                mp->d_seismograms_a,
-                                                                               mp->d_nu,
                                                                                mp->d_ispec_selected_rec_loc,
                                                                                it);
   if (*SAVE_SEISMOGRAMS_PRESSURE){

--- a/src/inverse_problem_for_model/specfem_interface/specfem_interface_mod.F90
+++ b/src/inverse_problem_for_model/specfem_interface/specfem_interface_mod.F90
@@ -263,13 +263,11 @@ contains
     if (allocated(gamma_receiver)) deallocate(gamma_receiver)
     if (allocated(station_name)) deallocate(station_name)
     if (allocated(network_name)) deallocate(network_name)
-    if (allocated(nu)) deallocate(nu)
 
     !! re-allocation
     allocate(islice_selected_rec(nrec),ispec_selected_rec(nrec))
     allocate(xi_receiver(nrec),eta_receiver(nrec),gamma_receiver(nrec))
     allocate(station_name(nrec),network_name(nrec))
-    allocate(nu(NDIM,NDIM,nrec))
 
     !! store current arrays
     islice_selected_rec(:)=acqui_simu(ievent)%islice_selected_rec(:)
@@ -279,19 +277,6 @@ contains
     gamma_receiver(:)=acqui_simu(ievent)%gamma_rec(:)
     station_name(:)=acqui_simu(ievent)%station_name
     network_name(:)=acqui_simu(ievent)%network_name
-
-    ! X coordinate - East
-    nu(1,1,:) = 1.d0
-    nu(1,2,:) = 0.d0
-    nu(1,3,:) = 0.d0
-    ! Y coordinate - North
-    nu(2,1,:) = 0.d0
-    nu(2,2,:) = 1.d0
-    nu(2,3,:) = 0.d0
-    ! Z coordinate - Vertical
-    nu(3,1,:) = 0.d0
-    nu(3,2,:) = 0.d0
-    nu(3,3,:) = 1.d0
 
     if (nrec_local > 0) then
 

--- a/src/specfem3D/compute_interpolated_dva.f90
+++ b/src/specfem3D/compute_interpolated_dva.f90
@@ -27,7 +27,6 @@
 
 subroutine compute_interpolated_dva_viscoelast(displ,veloc,accel,NGLOB_AB, &
                                     ispec,NSPEC_AB,ibool, &
-                                    xi_r,eta_r,gamma_r, &
                                     hxir,hetar,hgammar, &
                                     dxd,dyd,dzd,vxd,vyd,vzd,axd,ayd,azd)
 
@@ -44,9 +43,6 @@ subroutine compute_interpolated_dva_viscoelast(displ,veloc,accel,NGLOB_AB, &
   integer,intent(in) :: NSPEC_AB,NGLOB_AB
   real(kind=CUSTOM_REAL),dimension(NDIM,NGLOB_AB),intent(in) :: displ,veloc,accel
   integer,dimension(NGLLX,NGLLY,NGLLZ,NSPEC_AB),intent(in) :: ibool
-
-  ! receiver information
-  double precision,intent(in) :: xi_r,eta_r,gamma_r
 
   ! receiver Lagrange interpolators
   double precision,dimension(NGLLX),intent(in) :: hxir
@@ -68,52 +64,30 @@ subroutine compute_interpolated_dva_viscoelast(displ,veloc,accel,NGLOB_AB, &
   ayd = ZERO
   azd = ZERO
 
-  ! takes closest GLL point only (no interpolation)
-  if (FASTER_RECEIVERS_POINTS_ONLY) then
+  ! interpolates seismograms at exact receiver locations
+  do k = 1,NGLLZ
+    do j = 1,NGLLY
+      do i = 1,NGLLX
+        iglob = ibool(i,j,k,ispec)
 
-    iglob = ibool(nint(xi_r),nint(eta_r),nint(gamma_r),ispec)
+        hlagrange = hxir(i) * hetar(j) * hgammar(k)
 
-    ! displacement
-    dxd = dble(displ(1,iglob))
-    dyd = dble(displ(2,iglob))
-    dzd = dble(displ(3,iglob))
-    ! velocity
-    vxd = dble(veloc(1,iglob))
-    vyd = dble(veloc(2,iglob))
-    vzd = dble(veloc(3,iglob))
-    ! acceleration
-    axd = dble(accel(1,iglob))
-    ayd = dble(accel(2,iglob))
-    azd = dble(accel(3,iglob))
+        ! displacement
+        dxd = dxd + dble(displ(1,iglob))*hlagrange
+        dyd = dyd + dble(displ(2,iglob))*hlagrange
+        dzd = dzd + dble(displ(3,iglob))*hlagrange
+        ! velocity
+        vxd = vxd + dble(veloc(1,iglob))*hlagrange
+        vyd = vyd + dble(veloc(2,iglob))*hlagrange
+        vzd = vzd + dble(veloc(3,iglob))*hlagrange
+        ! acceleration
+        axd = axd + dble(accel(1,iglob))*hlagrange
+        ayd = ayd + dble(accel(2,iglob))*hlagrange
+        azd = azd + dble(accel(3,iglob))*hlagrange
 
-  else
-
-    ! interpolates seismograms at exact receiver locations
-    do k = 1,NGLLZ
-      do j = 1,NGLLY
-        do i = 1,NGLLX
-          iglob = ibool(i,j,k,ispec)
-
-          hlagrange = hxir(i) * hetar(j) * hgammar(k)
-
-          ! displacement
-          dxd = dxd + dble(displ(1,iglob))*hlagrange
-          dyd = dyd + dble(displ(2,iglob))*hlagrange
-          dzd = dzd + dble(displ(3,iglob))*hlagrange
-          ! velocity
-          vxd = vxd + dble(veloc(1,iglob))*hlagrange
-          vyd = vyd + dble(veloc(2,iglob))*hlagrange
-          vzd = vzd + dble(veloc(3,iglob))*hlagrange
-          ! acceleration
-          axd = axd + dble(accel(1,iglob))*hlagrange
-          ayd = ayd + dble(accel(2,iglob))*hlagrange
-          azd = azd + dble(accel(3,iglob))*hlagrange
-
-        enddo
       enddo
     enddo
-
-  endif
+  enddo
 
 end subroutine compute_interpolated_dva_viscoelast
 
@@ -124,7 +98,6 @@ end subroutine compute_interpolated_dva_viscoelast
 subroutine compute_interpolated_dva_acoust(displ_element,veloc_element,accel_element, &
                         potential_dot_dot_acoustic,potential_acoustic,NGLOB_AB, &
                         ispec,NSPEC_AB,ibool, &
-                        xi_r,eta_r,gamma_r, &
                         hxir,hetar,hgammar, &
                         dxd,dyd,dzd,vxd,vyd,vzd,axd,ayd,azd,pd,USE_TRICK_FOR_BETTER_PRESSURE)
 
@@ -147,8 +120,6 @@ subroutine compute_interpolated_dva_acoust(displ_element,veloc_element,accel_ele
 
   logical,intent(in) :: USE_TRICK_FOR_BETTER_PRESSURE
 
-  ! receiver information
-  double precision,intent(in) :: xi_r,eta_r,gamma_r
   ! Lagrange interpolators
   double precision,dimension(NGLLX),intent(in) :: hxir
   double precision,dimension(NGLLY),intent(in) :: hetar
@@ -173,115 +144,62 @@ subroutine compute_interpolated_dva_acoust(displ_element,veloc_element,accel_ele
 
   pd  = ZERO
 
-! takes closest GLL point only (no interpolation)
-  if (FASTER_RECEIVERS_POINTS_ONLY) then
+  ! interpolates seismograms at exact receiver locations
+  do k = 1,NGLLZ
+    do j = 1,NGLLY
+      do i = 1,NGLLX
 
-    ! displacement
-    dxd = displ_element(1,nint(xi_r),nint(eta_r),nint(gamma_r))
-    dyd = displ_element(2,nint(xi_r),nint(eta_r),nint(gamma_r))
-    dzd = displ_element(3,nint(xi_r),nint(eta_r),nint(gamma_r))
+        hlagrange = hxir(i) * hetar(j) * hgammar(k)
 
-    ! velocity
-    vxd = veloc_element(1,nint(xi_r),nint(eta_r),nint(gamma_r))
-    vyd = veloc_element(2,nint(xi_r),nint(eta_r),nint(gamma_r))
-    vzd = veloc_element(3,nint(xi_r),nint(eta_r),nint(gamma_r))
+        ! displacement
+        dxd = dxd + hlagrange*displ_element(1,i,j,k)
+        dyd = dyd + hlagrange*displ_element(2,i,j,k)
+        dzd = dzd + hlagrange*displ_element(3,i,j,k)
 
-    ! acceleration
-    axd = accel_element(1,nint(xi_r),nint(eta_r),nint(gamma_r))
-    ayd = accel_element(2,nint(xi_r),nint(eta_r),nint(gamma_r))
-    azd = accel_element(3,nint(xi_r),nint(eta_r),nint(gamma_r))
+        ! velocity
+        vxd = vxd + hlagrange*veloc_element(1,i,j,k)
+        vyd = vyd + hlagrange*veloc_element(2,i,j,k)
+        vzd = vzd + hlagrange*veloc_element(3,i,j,k)
 
-    ! global index
-    iglob = ibool(nint(xi_r),nint(eta_r),nint(gamma_r),ispec)
+        ! acceleration
+        axd = axd + hlagrange*accel_element(1,i,j,k)
+        ayd = ayd + hlagrange*accel_element(2,i,j,k)
+        azd = azd + hlagrange*accel_element(3,i,j,k)
 
-    ! pressure
-    if (USE_TRICK_FOR_BETTER_PRESSURE) then
-      ! use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:
-      ! use the second derivative of the source for the source time function instead of the source itself,
-      ! and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
-      ! this is mathematically equivalent, but numerically significantly more accurate because in the explicit
-      ! Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
-      ! thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
-      ! is accurate at second order and thus contains significantly less numerical noise.
-      pd = - potential_acoustic(iglob)
-      ! that trick is not implemented for the calculation of displacement, velocity nor acceleration seismograms
-      ! in acoustic elements yet; to do so we would need to recompute them using the second integral in time of the
-      ! current formulas in that case. Same remark for recording stations located in solid (elastic/viscoelastic) elements
-      ! in the case of fluid/solid models when that trick is used; thus for now we erase these seismograms here just in case
-      ! because they would be wrong
-      dxd = ZERO
-      dyd = ZERO
-      dzd = ZERO
-      vxd = ZERO
-      vyd = ZERO
-      vzd = ZERO
-      axd = ZERO
-      ayd = ZERO
-      azd = ZERO
-    else
-      pd = - potential_dot_dot_acoustic(iglob) ! this is the standard expression
-    endif
+        ! global index
+        iglob = ibool(i,j,k,ispec)
 
-  else
+        ! pressure
+        if (USE_TRICK_FOR_BETTER_PRESSURE) then
+          ! use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:
+          ! use the second derivative of the source for the source time function instead of the source itself,
+          ! and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
+          ! this is mathematically equivalent, but numerically significantly more accurate because in the explicit
+          ! Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
+          ! thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
+          ! is accurate at second order and thus contains significantly less numerical noise.
+          pd = pd - hlagrange*potential_acoustic(iglob)
+          ! that trick is not implemented for the calculation of displacement, velocity nor acceleration seismograms
+          ! in acoustic elements yet; to do so we would need to recompute them using the second integral in time of the
+          ! current formulas in that case. Same remark for recording stations located in solid (elastic/viscoelastic) elements
+          ! in the case of fluid/solid models when that trick is used; thus for now we erase these seismograms here just in case
+          ! because they would be wrong
+          dxd = ZERO
+          dyd = ZERO
+          dzd = ZERO
+          vxd = ZERO
+          vyd = ZERO
+          vzd = ZERO
+          axd = ZERO
+          ayd = ZERO
+          azd = ZERO
+        else
+          pd = pd - hlagrange*potential_dot_dot_acoustic(iglob)
+        endif
 
-! interpolates seismograms at exact receiver locations
-    do k = 1,NGLLZ
-      do j = 1,NGLLY
-        do i = 1,NGLLX
-
-          hlagrange = hxir(i) * hetar(j) * hgammar(k)
-
-          ! displacement
-          dxd = dxd + hlagrange*displ_element(1,i,j,k)
-          dyd = dyd + hlagrange*displ_element(2,i,j,k)
-          dzd = dzd + hlagrange*displ_element(3,i,j,k)
-
-          ! velocity
-          vxd = vxd + hlagrange*veloc_element(1,i,j,k)
-          vyd = vyd + hlagrange*veloc_element(2,i,j,k)
-          vzd = vzd + hlagrange*veloc_element(3,i,j,k)
-
-          ! acceleration
-          axd = axd + hlagrange*accel_element(1,i,j,k)
-          ayd = ayd + hlagrange*accel_element(2,i,j,k)
-          azd = azd + hlagrange*accel_element(3,i,j,k)
-
-          ! global index
-          iglob = ibool(i,j,k,ispec)
-
-          ! pressure
-          if (USE_TRICK_FOR_BETTER_PRESSURE) then
-            ! use a trick to increase accuracy of pressure seismograms in fluid (acoustic) elements:
-            ! use the second derivative of the source for the source time function instead of the source itself,
-            ! and then record -potential_acoustic() as pressure seismograms instead of -potential_dot_dot_acoustic();
-            ! this is mathematically equivalent, but numerically significantly more accurate because in the explicit
-            ! Newmark time scheme acceleration is accurate at zeroth order while displacement is accurate at second order,
-            ! thus in fluid elements potential_dot_dot_acoustic() is accurate at zeroth order while potential_acoustic()
-            ! is accurate at second order and thus contains significantly less numerical noise.
-            pd = pd - hlagrange*potential_acoustic(iglob)
-            ! that trick is not implemented for the calculation of displacement, velocity nor acceleration seismograms
-            ! in acoustic elements yet; to do so we would need to recompute them using the second integral in time of the
-            ! current formulas in that case. Same remark for recording stations located in solid (elastic/viscoelastic) elements
-            ! in the case of fluid/solid models when that trick is used; thus for now we erase these seismograms here just in case
-            ! because they would be wrong
-            dxd = ZERO
-            dyd = ZERO
-            dzd = ZERO
-            vxd = ZERO
-            vyd = ZERO
-            vzd = ZERO
-            axd = ZERO
-            ayd = ZERO
-            azd = ZERO
-          else
-            pd = pd - hlagrange*potential_dot_dot_acoustic(iglob)
-          endif
-
-        enddo
       enddo
     enddo
-
-  endif
+  enddo
 
 end subroutine compute_interpolated_dva_acoust
 

--- a/src/specfem3D/noise_tomography.f90
+++ b/src/specfem3D/noise_tomography.f90
@@ -235,7 +235,7 @@ end module user_noise_distribution
 
 ! read parameters
   subroutine read_parameters_noise(myrank,nrec,NSTEP,nmovie_points, &
-                                   islice_selected_rec,xi_receiver,eta_receiver,gamma_receiver,nu, &
+                                   islice_selected_rec,xi_receiver,eta_receiver,gamma_receiver, &
                                    noise_sourcearray,xigll,yigll,zigll, &
                                    ibool, &
                                    xstore,ystore,zstore, &
@@ -260,7 +260,6 @@ end module user_noise_distribution
   double precision, dimension(NGLLX) :: xigll
   double precision, dimension(NGLLY) :: yigll
   double precision, dimension(NGLLZ) :: zigll
-  double precision, dimension(NDIM,NDIM,nrec) :: nu
   real(kind=CUSTOM_REAL), dimension(NGLOB_AB_VAL) :: xstore,ystore,zstore
 
   integer :: num_free_surface_faces
@@ -307,7 +306,7 @@ end module user_noise_distribution
   if (myrank == islice_selected_rec(irec_master_noise) .or. myrank == 0) then ! myrank == 0 is used for output only
     call compute_arrays_source_noise(myrank, &
               xi_receiver(irec_master_noise),eta_receiver(irec_master_noise),gamma_receiver(irec_master_noise), &
-              nu(:,:,irec_master_noise),noise_sourcearray, xigll,yigll,zigll,NSTEP)
+              noise_sourcearray, xigll,yigll,zigll,NSTEP)
   endif
 
   ! noise distribution and noise direction
@@ -457,7 +456,7 @@ end module user_noise_distribution
 ! read and construct the "source" (source time function based upon noise spectrum)
 ! for "ensemble forward source"
   subroutine compute_arrays_source_noise(myrank, &
-                                         xi_noise,eta_noise,gamma_noise,nu_single,noise_sourcearray, &
+                                         xi_noise,eta_noise,gamma_noise,noise_sourcearray, &
                                          xigll,yigll,zigll,NSTEP)
 
   use constants
@@ -469,7 +468,6 @@ end module user_noise_distribution
   double precision, dimension(NGLLX) :: xigll
   double precision, dimension(NGLLY) :: yigll
   double precision, dimension(NGLLZ) :: zigll
-  double precision, dimension(NDIM,NDIM) :: nu_single  ! rotation matrix at the master receiver
   ! output parameters
   real(kind=CUSTOM_REAL) :: noise_sourcearray(NDIM,NGLLX,NGLLY,NGLLZ,NSTEP)
   ! local parameters
@@ -522,9 +520,7 @@ end module user_noise_distribution
 
   ! rotates to Cartesian
   do itime = 1, NSTEP
-    noise_src_u(:,itime) = nu_single(1,:) * noise_src(itime) * nu_master(1) &
-                         + nu_single(2,:) * noise_src(itime) * nu_master(2) &
-                         + nu_single(3,:) * noise_src(itime) * nu_master(3)
+    noise_src_u(:,itime) =  noise_src(itime) * nu_master(:) 
   enddo
 
   ! receiver interpolators

--- a/src/specfem3D/prepare_timerun.F90
+++ b/src/specfem3D/prepare_timerun.F90
@@ -1268,7 +1268,7 @@
 
     ! sets up noise source for master receiver station
     call read_parameters_noise(myrank,nrec,NSTEP,NGLLSQUARE*num_free_surface_faces, &
-                               islice_selected_rec,xi_receiver,eta_receiver,gamma_receiver,nu, &
+                               islice_selected_rec,xi_receiver,eta_receiver,gamma_receiver, &
                                noise_sourcearray,xigll,yigll,zigll, &
                                ibool, &
                                xstore,ystore,zstore, &
@@ -1339,7 +1339,7 @@
                                 USE_MESH_COLORING_GPU, &
                                 nspec_acoustic,nspec_elastic, &
                                 myrank,SAVE_FORWARD, &
-                                hxir_store,hetar_store,hgammar_store,nu, &
+                                hxir_store,hetar_store,hgammar_store, &
                                 islice_selected_rec,NSTEP)
 
 

--- a/src/specfem3D/setup_sources_receivers.f90
+++ b/src/specfem3D/setup_sources_receivers.f90
@@ -105,7 +105,7 @@
            hdur_Gaussian(NSOURCES), &
            utm_x_source(NSOURCES), &
            utm_y_source(NSOURCES), &
-           nu_source(3,3,NSOURCES), stat=ier)
+           stat=ier)
   if (ier /= 0) stop 'error allocating arrays for sources'
 
   if (USE_FORCE_POINT_SOURCE) then
@@ -132,15 +132,10 @@
 !
 ! returns:  islice_selected_source & ispec_selected_source,
 !                xi_source, eta_source & gamma_source
-  call locate_source(ibool,NSOURCES,myrank,NSPEC_AB,NGLOB_AB,NGNOD, &
-          xstore,ystore,zstore,xigll,yigll,zigll,NPROC, &
-          tshift_src,min_tshift_src_original,yr,jda,ho,mi,utm_x_source,utm_y_source, &
-          DT,hdur,Mxx,Myy,Mzz,Mxy,Mxz,Myz, &
+  call locate_source(NSOURCES,tshift_src,min_tshift_src_original,yr,jda,ho,mi,utm_x_source,utm_y_source, &
+          hdur,Mxx,Myy,Mzz,Mxy,Mxz,Myz, &
           islice_selected_source,ispec_selected_source, &
-          xi_source,eta_source,gamma_source, &
-          nu_source,iglob_is_surface_external_mesh,ispec_is_surface_external_mesh, &
-          ispec_is_acoustic,ispec_is_elastic,ispec_is_poroelastic, &
-          num_free_surface_faces,free_surface_ispec,free_surface_ijk)
+          xi_source,eta_source,gamma_source)
 
   if (abs(minval(tshift_src)) > TINYVAL) call exit_MPI(myrank,'one tshift_src must be zero, others must be positive')
 
@@ -462,18 +457,15 @@
            gamma_receiver(nrec), &
            station_name(nrec), &
            network_name(nrec), &
-           nu(NDIM,NDIM,nrec),stat=ier)
+           stat=ier)
   if (ier /= 0) stop 'error allocating arrays for receivers'
 
   ! locate receivers in the mesh
-  call locate_receivers(ibool,myrank,NSPEC_AB,NGLOB_AB,NGNOD, &
-                        xstore,ystore,zstore,xigll,yigll,zigll,filtered_rec_filename, &
-                        nrec,islice_selected_rec,ispec_selected_rec, &
-                        xi_receiver,eta_receiver,gamma_receiver,station_name,network_name,nu, &
-                        NPROC,utm_x_source(1),utm_y_source(1), &
-                        UTM_PROJECTION_ZONE,SUPPRESS_UTM_PROJECTION, &
-                        iglob_is_surface_external_mesh,ispec_is_surface_external_mesh, &
-                        num_free_surface_faces,free_surface_ispec,free_surface_ijk,SU_FORMAT)
+
+  ! locate receivers in the mesh
+  call locate_receivers(filtered_rec_filename,nrec,islice_selected_rec,ispec_selected_rec,&
+                        xi_receiver,eta_receiver,gamma_receiver,station_name,network_name,&
+                        utm_x_source(1),utm_y_source(1))
 
   ! count number of receivers located in this slice
   nrec_local = 0
@@ -702,11 +694,9 @@
 
                   ! we use an tilted force defined by its magnitude and the projections
                   ! of an arbitrary (non-unitary) direction vector on the E/N/Z_UP basis
-                  sourcearrayd(:,i,j,k) = factor_force_source(isource) * hlagrange * &
-                                          ( nu_source(1,:,isource) * comp_x + &
-                                            nu_source(2,:,isource) * comp_y + &
-                                            nu_source(3,:,isource) * comp_z )
-
+                  sourcearrayd(1,i,j,k) = factor_force_source(isource) * hlagrange * comp_x 
+                  sourcearrayd(2,i,j,k) = factor_force_source(isource) * hlagrange * comp_y
+                  sourcearrayd(3,i,j,k) = factor_force_source(isource) * hlagrange * comp_z
                 endif
               enddo
             enddo

--- a/src/specfem3D/specfem3D_par.F90
+++ b/src/specfem3D/specfem3D_par.F90
@@ -110,7 +110,6 @@ module specfem_par
   integer, dimension(:), allocatable :: islice_selected_source,ispec_selected_source
   real(kind=CUSTOM_REAL), dimension(:,:,:,:), allocatable :: sourcearray
   real(kind=CUSTOM_REAL), dimension(:,:,:,:,:), allocatable :: sourcearrays
-  double precision, dimension(:,:,:), allocatable :: nu_source
   double precision, dimension(:), allocatable :: Mxx,Myy,Mzz,Mxy,Mxz,Myz
   double precision, dimension(:), allocatable :: xi_source,eta_source,gamma_source
   double precision, dimension(:), allocatable :: tshift_src,hdur,hdur_Gaussian
@@ -134,7 +133,6 @@ module specfem_par
   double precision, dimension(:,:), allocatable :: hpxir_store,hpetar_store,hpgammar_store
 
 ! timing information for the stations
-  double precision, allocatable, dimension(:,:,:) :: nu
   character(len=MAX_LENGTH_STATION_NAME), allocatable, dimension(:) :: station_name
   character(len=MAX_LENGTH_NETWORK_NAME), allocatable, dimension(:) :: network_name
 


### PR DESCRIPTION
Rotation matrices of seismograms are removed, because they are everytime diagonal.
