### PR TITLE
More simplifications in source/receiver localization routines

### DIFF
--- a/setup/constants.h.in
+++ b/setup/constants.h.in
@@ -157,13 +157,6 @@
 
 ! sources
 
-! flag to exclude elements that are too far from target in source detection
-  logical, parameter :: USE_DISTANCE_CRITERION_SOURCES = .true.
-
-! interpolates position to find the best possible location for the source, between GLL points if needed.
-! note: this can be turned off to speedup location search and locate the source at the closest GLL point instead.
-  logical, parameter :: USE_BEST_LOCATION_FOR_SOURCE = .true.
-
 ! flag to print the details of source location
   logical, parameter :: SHOW_DETAILS_LOCATE_SOURCE = .false.
 
@@ -181,9 +174,6 @@
   double precision, parameter :: SOURCE_DECAY_MIMIC_TRIANGLE = 1.628d0
 
 ! receivers
-
-! flag to exclude elements that are too far from target in receiver detection
-  logical, parameter :: USE_DISTANCE_CRITERION_RECEIVERS = .true.
 
 ! use this t0 as earliest starting time rather than the automatically calculated one
 ! (must be positive and bigger than the automatically one to be effective;


### PR DESCRIPTION
Creation of common subroutines for locate_source and locate_receivers, which locate points in the mesh the same way. Based on Vadim implementation in framework.