### PR TITLE
Fix buildbot nighty build issue

### DIFF
--- a/src/specfem3D/locate_receivers.f90
+++ b/src/specfem3D/locate_receivers.f90
@@ -654,7 +654,7 @@
        distance_from_target = HUGEVAL
 
        do iproc=0, NPROC-1
-         if (distance_from_target >= distance_from_target_all(1,iproc)) then
+         if (distance_from_target > distance_from_target_all(1,iproc)) then
            distance_from_target =  distance_from_target_all(1,iproc)
            islice_selected_dummy(1) = iproc
            ispec_selected_dummy(1) = ispec_selected_all(1,iproc)


### PR DESCRIPTION
This was a very minor difference. In the case of a point located exactly between two MPI slices, the previous version was selecting the smallest slice number, whereas the new version chose the highest slice number. The original convention is restablished here, and should solve the buildbot nighty build issues.