### PR TITLE
deleted obsolete keyword num_quad_lloyd_steps

### DIFF
--- a/EXAMPLES/Gmsh_simple_lddrk/mesh_example_with_gmsh.py
+++ b/EXAMPLES/Gmsh_simple_lddrk/mesh_example_with_gmsh.py
@@ -383,7 +383,7 @@ def mesh_3D():
     print("")
 
     # meshing
-    points, cells, point_data, cell_data, field_data = pygmsh.generate_mesh(geom,verbose=True,num_quad_lloyd_steps=0)
+    points, cells, point_data, cell_data, field_data = pygmsh.generate_mesh(geom,verbose=True)
 
     # mesh info
     print("")


### PR DESCRIPTION
…from the call to pygmsh.generate_mesh in EXAMPLES/Gmsh_simple_lddrk.

This is to fix #1292 .