### PR TITLE
don't pass obsolete num_quad_lloyd_steps keyword to generate_mesh

### DIFF
--- a/EXAMPLES/Gmsh_simple_lddrk/mesh_example_with_gmsh.py
+++ b/EXAMPLES/Gmsh_simple_lddrk/mesh_example_with_gmsh.py
@@ -383,7 +383,7 @@ def mesh_3D():
     print("")
 
     # meshing
-    points, cells, point_data, cell_data, field_data = pygmsh.generate_mesh(geom,verbose=True,num_quad_lloyd_steps=0)
+    points, cells, point_data, cell_data, field_data = pygmsh.generate_mesh(geom,verbose=True)
 
     # mesh info
     print("")


### PR DESCRIPTION
This is another attempt at #1293 and #1294; see longer comment at #1293.