### PR TITLE
Devel

### DIFF
--- a/src/decompose_mesh/fault_scotch.f90
+++ b/src/decompose_mesh/fault_scotch.f90
@@ -53,7 +53,7 @@ module fault_scotch
                               ! but smaller than the smallest element size
 
   public :: read_fault_files, fault_repartition, close_faults, write_fault_database, &
-            save_nodes_coords, nodes_coords_open, ANY_FAULT
+            write_fault_database_mpi, save_nodes_coords, nodes_coords_open, ANY_FAULT, bcast_faults_mpi
 
 CONTAINS
 
@@ -605,6 +605,108 @@ CONTAINS
   enddo
 
   end subroutine write_fault_database
+
+
+! ---------------------------------------------------------------------------------------------------
+! Below functions are only used for the mpi version
+! ---------------------------------------------------------------------------------------------------
+
+  subroutine write_fault_database_mpi(IIN_database, myrank, nE, glob2loc_elmnt, ipart, &
+             nnodes, glob2loc_nodes, NGNOD2D, nnodes_loc, nodes_coords)
+  integer, intent(in)  :: IIN_database
+  integer, intent(in)  :: myrank
+  integer, intent(in)  :: nE, nnodes, NGNOD2D
+  integer, dimension(nE), intent(in)  :: ipart
+  integer, dimension(nE), intent(in)  :: glob2loc_elmnt
+  integer, dimension(nnodes), intent(in) :: glob2loc_nodes
+
+  integer, intent(in)  :: nnodes_loc
+  double precision, dimension(NDIM,nnodes), intent(in)  :: nodes_coords
+
+  integer :: iflt, i, inode
+  integer :: iE, iE_loc
+  integer :: nspec_fault_1,nspec_fault_2
+  integer :: inodes(NGNOD2D), node_loc(NGNOD2D)
+
+        do iflt=1,size(faults)
+             ! get number of fault elements in this partition
+            nspec_fault_1 = count( ipart(faults(iflt)%ispec1) == myrank + 1)
+            nspec_fault_2 = count( ipart(faults(iflt)%ispec2) == myrank + 1)
+        
+            if (nspec_fault_1 /= nspec_fault_2) then
+              print *, 'Fault # ',iflt,', proc # ',myrank
+              print *, '  ispec1 : ', nspec_fault_1
+              print *, '  ispec2 : ', nspec_fault_2
+              print *, 'Fatal error: Number of fault elements do not coincide. Abort.'
+              stop
+            endif
+            write(IIN_database) nspec_fault_1
+        
+           ! if no fault element in this partition, move to next fault
+            if (nspec_fault_1 == 0) cycle
+
+            do i=1, faults(iflt)%nspec
+               iE = faults(iflt)%ispec1(i)
+               if (ipart(iE) /= myrank +1) cycle
+               iE_loc=glob2loc_elmnt(iE)
+
+               inodes = faults(iflt)%inodes1(:,i)
+               do inode = 1, NGNOD2D
+                  node_loc(inode) = glob2loc_nodes(inodes(inode))
+               enddo
+               write(IIN_database) iE_loc, node_loc(1:NGNOD2D)
+            enddo
+
+            do i=1, faults(iflt)%nspec
+               iE = faults(iflt)%ispec2(i)
+               if (ipart(iE) /= myrank +1) cycle
+               iE_loc=glob2loc_elmnt(iE)
+
+               inodes = faults(iflt)%inodes2(:,i)
+               do inode = 1, NGNOD2D
+                  node_loc(inode) = glob2loc_nodes(inodes(inode))
+               enddo
+               write(IIN_database) iE_loc, node_loc(1:NGNOD2D)
+            enddo
+        enddo
+        
+  end subroutine write_fault_database_mpi
+
+
+  subroutine bcast_faults_mpi(myrank)
+
+  integer, intent(in)  :: myrank
+  integer :: nbfaults  , iflt, ier, nspec
+  
+  if(myrank == 0)  then
+      nbfaults = size(faults)
+  endif
+  call bcast_all_singlei(nbfaults) 
+  if(myrank /= 0 ) then
+      allocate(faults(nbfaults),stat=ier)
+      if (ier /= 0) call exit_MPI_without_rank('error allocating array 78')
+  endif
+
+  do iflt = 1 , nbfaults
+     call bcast_all_singlei(faults(iflt)%nspec)
+     nspec = faults(iflt)%nspec
+     if(myrank /= 0 ) then
+        allocate(faults(iflt)%ispec1(nspec),stat=ier)
+        if (ier /= 0) call exit_MPI_without_rank('error allocating array 78')
+        allocate(faults(iflt)%ispec2(nspec),stat=ier)
+        if (ier /= 0) call exit_MPI_without_rank('error allocating array 78')
+        allocate(faults(iflt)%inodes1(NGNOD2D,nspec),stat=ier)
+        if (ier /= 0) call exit_MPI_without_rank('error allocating array 78')
+        allocate(faults(iflt)%inodes2(NGNOD2D,nspec),stat=ier)
+        if (ier /= 0) call exit_MPI_without_rank('error allocating array 78')
+     endif
+     call bcast_all_i(faults(iflt)%ispec1,  nspec)
+     call bcast_all_i(faults(iflt)%ispec2,  nspec)
+     call bcast_all_i(faults(iflt)%inodes1, nspec*NGNOD2D)
+     call bcast_all_i(faults(iflt)%inodes2, nspec*NGNOD2D)
+  enddo
+
+  end subroutine bcast_faults_mpi
 
 end module fault_scotch
 

--- a/src/decompose_mesh/module_database.f90
+++ b/src/decompose_mesh/module_database.f90
@@ -29,6 +29,7 @@ module module_database
 
   use constants, only: NDIM,IIN_DB2
   use shared_parameters, only: NGNOD, NGNOD2D, LOCAL_PATH, MSL => MAX_STRING_LEN
+  use fault_scotch
 
   integer                                     :: nE_loc
   integer, dimension(:),  allocatable         :: loc2glob_elmnt
@@ -76,8 +77,8 @@ contains
 ! write database for xgenerate_database
 !
 !----------------------------------
-
-  subroutine write_database(myrank, ipart, elmnts, nodes_coords, elmnts_glob,  num_modele,  mat_prop, &
+  subroutine write_database(myrank, ipart, elmnts, nodes_coords, nodes_coords_open_loc,&
+           iboundary, nspec_part_boundaries, elmnts_part_boundaries,  num_modele,  mat_prop, &
        undef_mat_prop, count_def_mat, count_undef_mat, ibelm_xmin, ibelm_xmax, ibelm_ymin, ibelm_ymax, &
        ibelm_bottom, ibelm_top, nodes_ibelm_xmin, nodes_ibelm_xmax, nodes_ibelm_ymin, nodes_ibelm_ymax, &
        nodes_ibelm_bottom, nodes_ibelm_top, cpml_to_spec, cpml_regions, is_cpml, ibelm_moho, nodes_ibelm_moho, &
@@ -88,14 +89,15 @@ contains
 
     integer,                                              intent(in)  :: myrank
     integer,                                              intent(in)  :: nnodes, nE
+    integer,                                              intent(in)  :: nspec_part_boundaries
     integer,                                              intent(in)  :: count_def_mat
     integer,                                              intent(in)  :: count_undef_mat
     integer,                                              intent(in)  :: nspec2D_xmin, nspec2D_xmax
     integer,                                              intent(in)  :: nspec2D_ymin, nspec2D_ymax
     integer,                                              intent(in)  :: nspec2D_bottom, nspec2D_top
     integer,                                              intent(in)  :: nspec_cpml, nspec2D_moho
-    integer,            dimension(nE),                    intent(in)  :: ipart
-    integer,            dimension(NGNOD,nE),              intent(in)  :: elmnts_glob
+    integer,            dimension(nE),                    intent(in)  :: ipart, iboundary
+    integer,   dimension(NGNOD,nspec_part_boundaries),    intent(in)  :: elmnts_part_boundaries
     integer,            dimension(NGNOD,nE_loc),          intent(in)  :: elmnts
     integer,            dimension(2,nE),                  intent(in)  :: num_modele
     integer,            dimension(nspec2D_xmin),          intent(in)  :: ibelm_xmin
@@ -116,11 +118,12 @@ contains
     double precision,   dimension(17,count_def_mat),      intent(in)  :: mat_prop
     character(len=MSL), dimension(6,count_undef_mat),     intent(in)  :: undef_mat_prop
     double precision,   dimension(NDIM,nnodes),           intent(in)  :: nodes_coords
+    double precision,   dimension(NDIM,nnodes),           intent(in)  :: nodes_coords_open_loc
     logical,            dimension(nE),                    intent(in)  :: is_cpml
 
-    character(len=20)                                                 :: prname
+    character(len=26)                                                 :: prname
     integer                                                           :: i1, i2, in1, in2
-    integer                                                           :: inode, i, k
+    integer                                                           :: inode, i, k, iB
     integer                                                           :: islice, kE
     integer                                                           :: iE, iE_loc, iE_n
     integer                                                           :: nspec_cpml_local
@@ -284,7 +287,8 @@ contains
                 do i1 = 1, NGNOD                    !! loop over edges on my element
                    in1 = elmnts(i1,iE_loc)
                    do i2 = 1, NGNOD                 !! loop over edges on my neighbor element
-                      in2 = elmnts_glob(i2,iE_n)    !! pb on utilise elmnts_glob
+                      iB  = iboundary(iE_n)
+                      in2 = elmnts_part_boundaries(i2,iB)
                       if (in1 == in2 ) then         !! it's common edge
                          k = k + 1
                          liste_comm_nodes(k) = glob2loc_nodes(in1)  !! store it in local numbering
@@ -349,6 +353,33 @@ contains
        enddo
     endif
     close(IIN_database)
+
+     ! write fault database 
+     call bcast_all_singlel(ANY_FAULT)
+     if (ANY_FAULT) then
+        write(prname, "(i6.6,'_Database_fault')") myrank
+        open(unit=16,file=LOCAL_PATH(1:len_trim(LOCAL_PATH))//'/proc'//prname,&
+             status='unknown', action='write', form='unformatted', iostat = ier)
+        if (ier /= 0) then
+          print *,'Error file open:',LOCAL_PATH(1:len_trim(LOCAL_PATH))//'/proc'//prname
+          print *
+          print *,'check if path exists:',LOCAL_PATH(1:len_trim(LOCAL_PATH))
+          stop
+        endif
+
+        call bcast_faults_mpi(myrank)
+ 
+        call write_fault_database_mpi(16, myrank, nE, glob2loc_elmnt, ipart,&
+                         size(glob2loc_nodes), glob2loc_nodes, NGNOD2D, nnodes_loc, nodes_coords)
+
+!    The local locations need to be saved in Database_fault files.
+        write(16) nnodes_loc
+        do inode = 1, nnodes_loc
+           k = inode !loc2glob_nodes(inode)
+           write(16) inode,nodes_coords_open_loc(1,k),nodes_coords_open_loc(2,k),nodes_coords_open_loc(3,k)
+        enddo
+        close(16)
+     endif
 
   end subroutine write_database
 

--- a/src/decompose_mesh/module_mesh.f90
+++ b/src/decompose_mesh/module_mesh.f90
@@ -36,9 +36,14 @@ module module_mesh
   integer,               dimension(:,:),        allocatable  :: elmnts, elmnts_glob
   integer,               dimension(:,:),        allocatable  :: mat
 
+  integer                                                    :: nspec_part_boundaries
+  integer,               dimension(:,:),        allocatable  :: elmnts_part_boundaries
+  integer,               dimension(:),          allocatable  :: iboundary
+
   ! vertices
   integer                                                    :: nnodes, nnodes_glob
   double precision,      dimension(:,:),         allocatable :: nodes_coords, nodes_coords_glob
+  double precision,      dimension(:,:),         allocatable :: nodes_coords_open_loc
 
   ! boundaries
   integer                                                    :: ispec2D
@@ -767,9 +772,10 @@ contains
     if (nspec2D_moho > 0) write(27,*) '  nspec2D_moho = ', nspec2D_moho
 
     call read_fault_files(localpath_name)
+
     if (ANY_FAULT) then
-       call save_nodes_coords(nodes_coords,nnodes)
-       call close_faults(nodes_coords,nnodes)
+       call save_nodes_coords(nodes_coords_glob,nnodes_glob)
+       call close_faults(nodes_coords_glob,nnodes_glob)
     endif
 
   end subroutine read_mesh_files


### PR DESCRIPTION
Adding parallel decomposition for fault mesh. 
This new function is used to parallelly decompose very big meshes with faults for the dynamic rupture simulations, when the series decomposition is limited by the memory of single computing node.