### PR TITLE
Modify the calculation of the steepest descent direction in src/tomography/get_sd_direction.f90

### DIFF
--- a/src/tomography/get_sd_direction.f90
+++ b/src/tomography/get_sd_direction.f90
@@ -57,8 +57,7 @@
   double precision, dimension(NGLLX,NGLLY,NGLLZ) :: wgll_cube
 
   real(kind=CUSTOM_REAL) :: jacobianl
-  integer :: iglob
-  integer :: i,j,k,ier,ival,ispec,ispec_irreg,NSPEC_IRREGULAR,s1_jac,s2_jac,s3_jac,s4_jac
+  integer :: ival,ispec_irreg,NSPEC_IRREGULAR,s1_jac,s2_jac,s3_jac,s4_jac
   character(len=MAX_STRING_LEN) :: m_file
 
 ! reads NSPEC_IRREGULAR

--- a/src/tomography/rules.mk
+++ b/src/tomography/rules.mk
@@ -152,6 +152,7 @@ ${E}/xadd_model_iso: $(xadd_model_iso_OBJECTS) $(xadd_model_SHARED_OBJECTS) $(CO
 ##
 xmodel_update_OBJECTS = \
 	$O/tomography_par.tomo_module.o \
+	$O/compute_kernel_integral.tomo.o \
 	$O/get_sd_direction.tomo.o \
 	$O/model_update.tomo.o \
 	$O/read_kernels.tomo.o \


### PR DESCRIPTION
As a discrete version of the formulas (e.g. eq. (16)) in Tromp et al. (2005), should the steepest descent direction be 
model_dbeta(i,j,k,ispec) = - kernel_beta(i,j,k,ispec) * volumel
instead of
model_dbeta(i,j,k,ispec) = - kernel_beta(i,j,k,ispec) ?
where as the volumel is the volume associated with GLL point of index (i,j,k,ispec)


![image](https://user-images.githubusercontent.com/45736336/161282725-404b2c10-6257-4dde-ad5d-448f36fa7efb.png)

