### PR TITLE
Add accidentally removed file and update directory paths

### DIFF
--- a/EXAMPLES/small_example_coupling_axisem_specfem_script/README_INSTALL
+++ b/EXAMPLES/small_example_coupling_axisem_specfem_script/README_INSTALL
@@ -34,7 +34,7 @@ INSTALLATION of Hybrid Specfem / axisem
 
   4-- compile tools for coupling Axisem/Specfem 
 
-     go to ./EXTERNAL_PACKAGES_coupled_with_SPECFEM3D/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM 
+     go to ./external_libs/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM
      and type
  
             make all 

--- a/EXAMPLES/small_example_coupling_axisem_specfem_script/run_this_exemple_by_scritp.sh
+++ b/EXAMPLES/small_example_coupling_axisem_specfem_script/run_this_exemple_by_scritp.sh
@@ -20,10 +20,10 @@ Param=Param_files
 ########################    TRACTION DATABASES GENERATION   ########################################################
 
 # directory containing axisem modified for specfem coupling
-axisem_sources=$rootdir/EXTERNAL_PACKAGES_coupled_with_SPECFEM3D/AxiSEM_for_SPECFEM3D/AxiSEM_modif_for_coupling_with_specfem
+axisem_sources=$rootdir/external_libs/AxiSEM_for_SPECFEM3D/AxiSEM_modif_for_coupling_with_specfem
 
 # directory containing utils for coupling axisem/specfem
-axisem_utils_coupling=$rootdir/EXTERNAL_PACKAGES_coupled_with_SPECFEM3D/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM
+axisem_utils_coupling=$rootdir/external_libs/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM
 
 
 # ------------- copy inputs files for specfem  ------------

--- a/external_libs/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM/config.h
+++ b/external_libs/AxiSEM_for_SPECFEM3D/UTILS_COUPLING_SpecFEM/config.h
@@ -1,0 +1,59 @@
+CC=icc
+FC=mpif90
+CCFLAGS = -O3
+# for debugging: change -O3 -check nobounds to      -check all -debug -g -O0 -fp-stack-check -traceback -ftrapuv
+
+# for full vectorization on CURIE, change -xHost to -xAVX (since the frontend node has Nehalem processors, not Sandy Bridge)
+
+FFLAGS = -O3 -check nobounds -xAVX -ftz -assume buffered_io -assume byterecl -vec-report0 -implicitnone -warn truncated_source -warn argument_checking -warn declarations -warn alignments -warn ignore_loc -warn usage -mcmodel=large -shared-intel
+
+#FFLAGS = -check all -debug -g -O0 -fp-stack-check -traceback -ftrapuv -implicitnone -warn truncated_source -warn argument_checking -warn declarations -warn alignments -warn ignore_loc -warn usage -mcmodel=medium -shared-intel
+
+
+################################################
+#   Intel ifort
+################################################
+
+# it is crucial to use -xAVX here, so that big loops that contain double precision complex numbers are vectorized;
+# this means that only Intel Sandy Bridge processors can vectorize these loops, not Intel Nehalem processors,
+# since they only have SSE4.2 vector instructions but not AVX (Advanced Vector Extensions).
+# option "-assume buffered_io" is important especially on
+# parallel file systems like SFS 3.2 / Lustre 1.8. If omitted
+# I/O throughput lingers at 2.5 MB/s, with it it can increase to ~44 MB/s
+# However it does not make much of a difference on NFS mounted volumes or with SFS 3.1.1 / Lustre 1.6.7.1
+#FC = mpif90
+#FFLAGS = -O3 -check nobounds -xAVX -ftz -assume buffered_io -assume byterecl -vec-report3 -implicitnone -warn truncated_source -warn argument_checking -warn declarations -warn alignments -warn ignore_loc -warn usage -mcmodel=medium -shared-intel
+
+# useful for debugging:
+#  change   -O3 -check nobounds     to      -check all -debug -g -O0 -fp-stack-check -traceback -ftrapuv
+
+# change    -vec-report0      to      -vec-report3     to get a vectorization report
+
+################################################
+#   GNU gfortran
+################################################
+
+#FC = mpif90
+#FFLAGS = -std=gnu -fimplicit-none -frange-check -O2 -pedantic -pedantic-errors -Waliasing -Wampersand -Wline-truncation -Wsurprising -Wunderflow -fbounds-check
+
+################################################
+#   IBM Blue Gene
+################################################
+
+# at IDRIS (France) maybe change -qarch=auto to -qarch=450d
+#
+# you will probably need to add " module load bgq-xl " or similar to your .bash_profile to load the compilers
+#
+# It could also help to put this in your .bash_profile: export XLFRTEOPTS=aggressive_array_io=yes:buffering=enable
+#
+# On some (but not all) IBM machines one might need to add -qsave otherwise the IBM compiler allocates the
+# arrays in the stack and the code crashes if the stack size is too
+# small (which is sometimes the case, but less often these days on large machines)
+#
+# to debug with IBM xlf, one can add this: -g -O0 -C -qddim -qfullpath -qflttrap=overflow:zerodivide:invalid:enable -qfloat=nans -qinitauto=7FBFFFFF
+#
+# options -qreport -qsource -qlist create a *.lst file containing detailed information about vectorization
+#
+#FC = mpixlf95_r
+#FFLAGS = -O4 -qnostrict -qhot -qsimd=auto -qassert=contig -g -Q -qarch=auto -q64 -qfree=f90 -qsuffix=f=f90 -qsuppress=1500-036 -qreport -qsource -qlist
+


### PR DESCRIPTION
Fix a bit of fallout from #1542.

The config file was accidentally removed in #1542, because config.h is listed in .gitignore (so when @ykane ran `git add` the file was not correctly added again). I copied the file from the original place so this PR should restore the previous file.

And I updated all directory paths that referenced the old directory location.